### PR TITLE
rename SystemNotReturned to ItemNotReturned

### DIFF
--- a/kerlescan/exceptions.py
+++ b/kerlescan/exceptions.py
@@ -17,12 +17,12 @@ class HTTPError(Exception):
         self.status_code = status_code
 
 
-class SystemNotReturned(Exception):
+class ItemNotReturned(Exception):
     def __init__(self, message):
         """
-        Raise this exception if a system was not returned by inventory service
+        Raise this exception if an item was not returned by inventory service
         """
-        super(SystemNotReturned, self).__init__()
+        super(ItemNotReturned, self).__init__()
         self.message = message
 
 

--- a/kerlescan/inventory_service_interface.py
+++ b/kerlescan/inventory_service_interface.py
@@ -4,7 +4,7 @@ from kerlescan import config
 from kerlescan.constants import AUTH_HEADER_NAME, INVENTORY_SVC_SYSTEMS_ENDPOINT
 from kerlescan.constants import INVENTORY_SVC_SYSTEM_PROFILES_ENDPOINT
 from kerlescan.constants import SYSTEM_PROFILE_INTEGERS, SYSTEM_PROFILE_STRINGS
-from kerlescan.exceptions import SystemNotReturned
+from kerlescan.exceptions import ItemNotReturned
 from kerlescan.service_interface import fetch_data
 
 
@@ -17,9 +17,7 @@ def _ensure_correct_system_count(system_ids_requested, result):
     if len(result) < len(system_ids_requested):
         system_ids_returned = {system["id"] for system in result}
         missing_ids = set(system_ids_requested) - system_ids_returned
-        raise SystemNotReturned(
-            "System(s) %s not available to display" % ",".join(missing_ids)
-        )
+        raise ItemNotReturned("%s not available to display" % ",".join(missing_ids))
 
 
 def fetch_systems_with_profiles(system_ids, service_auth_key, logger, counters):


### PR DESCRIPTION
rename exception to make it applicable for both baselines and systems.