### PR TITLE
feature: add BYPASS_RBAC env var

### DIFF
--- a/kerlescan/config.py
+++ b/kerlescan/config.py
@@ -12,3 +12,5 @@ hsp_svc_hostname = os.getenv("HSP_SVC_URL", "http://hsp_svc_url_is_not_set")
 prometheus_multiproc_dir = os.getenv("prometheus_multiproc_dir", None)
 
 path_prefix = os.getenv("PATH_PREFIX", "/api/")
+
+bypass_rbac = os.getenv("BYPASS_RBAC", None)

--- a/kerlescan/view_helpers.py
+++ b/kerlescan/view_helpers.py
@@ -4,7 +4,7 @@ import base64
 
 from http import HTTPStatus
 
-from kerlescan.config import path_prefix
+from kerlescan.config import path_prefix, bypass_rbac
 from kerlescan.service_interface import get_key_from_headers
 from kerlescan.rbac_service_interface import get_roles
 from kerlescan.exceptions import HTTPError
@@ -52,6 +52,9 @@ def ensure_has_role(**kwargs):
     ensure role exists. kwargs needs to contain:
         role, application, app_name, request, logger, request_metric, exception_metric
     """
+    if bypass_rbac == "BYPASS":
+        return
+
     request = kwargs["request"]
     if _is_mgmt_url(request.path) or _is_openapi_url(request.path, kwargs["app_name"]):
         return  # allow request


### PR DESCRIPTION
If `BYPASS_RBAC` is set to `BYPASS`, the rbac check will always pass.
This is useful for enabling/disabling the feature.