### PR TITLE
fix: disable account check for mgmt urls

### DIFF
--- a/kerlescan/view_helpers.py
+++ b/kerlescan/view_helpers.py
@@ -36,6 +36,9 @@ def _is_openapi_url(path, app_name):
 
 
 def ensure_account_number(request, logger):
+    if _is_mgmt_url(request.path):  # TODO: pass in app_name for openapi url check
+        return  # allow request
+
     auth_key = get_key_from_headers(request.headers)
     if auth_key:
         identity = json.loads(base64.b64decode(auth_key))["identity"]


### PR DESCRIPTION
This commit disables the account check for mgmt urls. I need to also
disable it for openapi.json but will do that in a different commit.
The latter requires more thought wrt backwards compatibility for other
callers.