### PR TITLE
disable log group creation

### DIFF
--- a/kerlescan/cloudwatch.py
+++ b/kerlescan/cloudwatch.py
@@ -31,6 +31,7 @@ def setup_cw_logging(logger):  # pragma: no cover
         boto3_session=session,
         log_group=os.environ.get("CW_LOG_GROUP", "platform-dev"),
         stream_name=namespace,
+        create_log_group=False,
     )
 
     logger.addHandler(handler)


### PR DESCRIPTION
Watchtower will attempt to create a cloudwatch log group by default.
However, log group creation has been disabled. We should not attempt
to create a log group (per platform team).