### PR TITLE
Support additional query parameters when creating pagination links.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,10 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# Eclipse/PyDev settings
+.project
+.pydevproject
+
 # mkdocs documentation
 /site
 

--- a/kerlescan/paginate.py
+++ b/kerlescan/paginate.py
@@ -1,73 +1,56 @@
 from flask import request, Response
+from urllib.parse import urlencode
 import json
 
-pagination_link_template = "%s?limit=%s&offset=%s&order_by=%s&order_how=%s"
+
+def _create_link(path, limit, offset, order_by, order_how, args_dict):
+    # copy of the dict passed in so we don't modify the original
+    params = dict(args_dict)
+    params["limit"] = limit
+    params["offset"] = offset
+    params["order_by"] = order_by
+    params["order_how"] = order_how
+    return "{}?{}".format(path, urlencode(params))
 
 
-def _create_first_link(path, limit, offset, count, order_by, order_how):
+def _create_first_link(path, limit, offset, count, order_by, order_how, args_dict):
     # Example return string:
     # "/api/item-service/v1/items?limit=20&offset=0&order_by=captured_date&order_how=desc"
-    first_link = pagination_link_template % (path, limit, 0, order_by, order_how)
-    return first_link
+    return _create_link(path, limit, 0, order_by, order_how, args_dict)
 
 
-def _create_previous_link(path, limit, offset, count, order_by, order_how):
+def _create_previous_link(path, limit, offset, count, order_by, order_how, args_dict):
     # if we are at the beginning, do not create a previous link
     # Example return string:
     # "/api/item-service/v1/items?limit=20&offset=20&order_by=captured_date&order_how=desc"
     if offset == 0 or offset - limit < 0:
-        return _create_first_link(path, limit, offset, count, order_by, order_how)
-    previous_link = pagination_link_template % (
-        request.path,
-        limit,
-        offset - limit,
-        order_by,
-        order_how,
-    )
-    return previous_link
+        return _create_first_link(
+            path, limit, offset, count, order_by, order_how, args_dict
+        )
+    return _create_link(path, limit, offset - limit, order_by, order_how, args_dict)
 
 
-def _create_next_link(path, limit, offset, count, order_by, order_how):
+def _create_next_link(path, limit, offset, count, order_by, order_how, args_dict):
     # if we are at the end, do not create a next link
     # Example return string:
     # "/api/item-service/v1/items?limit=20&offset=40&order_by=captured_date&order_how=desc"
     if limit + offset >= count:
-        return _create_last_link(path, limit, offset, count, order_by, order_how)
-    next_link = pagination_link_template % (
-        request.path,
-        limit,
-        limit + offset,
-        order_by,
-        order_how,
-    )
-    return next_link
+        return _create_last_link(
+            path, limit, offset, count, order_by, order_how, args_dict
+        )
+    return _create_link(path, limit, limit + offset, order_by, order_how, args_dict)
 
 
-def _create_last_link(path, limit, offset, count, order_by, order_how):
+def _create_last_link(path, limit, offset, count, order_by, order_how, args_dict):
     # Example return string:
     # "/api/item-service/v1/items?limit=20&offset=100&order_by=captured_date&order_how=desc"
     final_offset = count - limit if (count - limit) >= 0 else 0
-    last_link = pagination_link_template % (
-        path,
-        limit,
-        final_offset,
-        order_by,
-        order_how,
-    )
-    return last_link
+    return _create_link(path, limit, final_offset, order_by, order_how, args_dict)
 
 
 def build_paginated_baseline_list_response(
-    limit, offset, order_by, order_how, json_list, total_available, count
+    limit, offset, order_by, order_how, json_list, total_available, count, args_dict={}
 ):
-    link_params = {
-        "path": request.path,
-        "limit": limit,
-        "offset": offset,
-        "order_by": order_by,
-        "order_how": order_how,
-        "count": count,
-    }
     json_output = {
         "meta": {
             "count": count,
@@ -76,10 +59,18 @@ def build_paginated_baseline_list_response(
             "total_available": total_available,
         },
         "links": {
-            "first": _create_first_link(**link_params),
-            "next": _create_next_link(**link_params),
-            "previous": _create_previous_link(**link_params),
-            "last": _create_last_link(**link_params),
+            "first": _create_first_link(
+                request.path, limit, offset, count, order_by, order_how, args_dict
+            ),
+            "next": _create_next_link(
+                request.path, limit, offset, count, order_by, order_how, args_dict
+            ),
+            "previous": _create_previous_link(
+                request.path, limit, offset, count, order_by, order_how, args_dict
+            ),
+            "last": _create_last_link(
+                request.path, limit, offset, count, order_by, order_how, args_dict
+            ),
         },
         "data": json_list,
     }


### PR DESCRIPTION
This is to fix bug when getting baselines filtered by display_name, the pagination urls need to include the display_name query parameter.